### PR TITLE
Removed templates directory from path

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -1399,7 +1399,7 @@ No resource limits.
 +
 . Create a Deployment in this new Namespace using a configuration file:
 +
-  $ deployment-namespace.yaml
+  $ cat deployment-namespace.yaml
 	apiVersion: extensions/v1beta1
 	kind: Deployment
 	metadata:
@@ -1446,7 +1446,7 @@ Alternatively, a namespace can be created using `kubectl` as well.
 
 . Create a Deployment:
 
-	$ kubectl -n dev2 apply -f templates/deployment.yaml
+	$ kubectl -n dev2 apply -f deployment.yaml
 	deployment "nginx-deployment-ns" created
 
 . Get Deployments in the newly created Namespace:


### PR DESCRIPTION
Tutorial already has you sitting in the templates path

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
